### PR TITLE
Fix spelling of "latitude"

### DIFF
--- a/libraries/gps_SwSerial/src/gps_SwSerial.cpp
+++ b/libraries/gps_SwSerial/src/gps_SwSerial.cpp
@@ -92,7 +92,7 @@ String SwSerialGPS::report()  {
     }
 
     if (tinygps->location.isValid()) {
-        root["Lattitude"] = location.lat();
+        root["Latitude"] = location.lat();
         root["Longitude"] = location.lng();
         ready = true;
     } else {


### PR DESCRIPTION
simple spelling fix for the word "latitude".
